### PR TITLE
Update abelsiqueira/COPIERTemplate.jl to JuliaBesties/BestieTemplate.jl

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -11,4 +11,4 @@ PackageUUID: c81ce882-e686-4888-976a-ce42bb892d34
 RunJuliaNightlyOnCI: true
 UseCirrusCI: true
 _commit: v0.2.2
-_src_path: https://github.com/abelsiqueira/COPIERTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
